### PR TITLE
Selecting a country now triggers editingChanged action

### DIFF
--- a/CTKFlagPhoneNumber/CTKFlagPhoneNumberTextField.swift
+++ b/CTKFlagPhoneNumber/CTKFlagPhoneNumberTextField.swift
@@ -276,7 +276,7 @@ open class CTKFlagPhoneNumberTextField: UITextField, UITextFieldDelegate, Countr
 		flagButton.setImage(flag, for: .normal)
 		text = phoneCode
 		
-		didEditText()
+		sendActions(for: .editingChanged)
 	}
 
 	// CTKFlagPhoneNumberDelegate


### PR DESCRIPTION
This way, removal of phone number can be handled.

I was using the textfield and getPhoneNumber() to enable / disable a button, but this method failed when the country was changed - no callback is called, so if phone was valid before, this button will stay enabled.

Triggering editingChanged will also call didEditText, and propagate the change to other observers.