### PR TITLE
Update to podspec file

### DIFF
--- a/FlagPhoneNumber.podspec
+++ b/FlagPhoneNumber.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
 	s.name             = 'FlagPhoneNumber'
-	s.version          = '0.8.0'
+	s.version          = '0.8.1'
 	s.summary          = 'A formatted phone number UITextField with country flag picker.'
 
 	# This description is used to generate tags and improve search results.
@@ -28,7 +28,8 @@ Pod::Spec.new do |s|
 
 	s.ios.deployment_target = '8.0'
 	s.source_files = 'Sources/**/*.swift'
-	s.resource_bundles = {'FlagPhoneNumber' => ['Sources/Resources/**/*']}
+	#s.resource_bundles = {'FlagPhoneNumber' => ['Sources/Resources/**/*']}
+	s.resources = 'Sources/Resources/**'
 	s.swift_version = '5.0'
 	s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
 


### PR DESCRIPTION
Instead of making use of `resource_bundles`, I have changed it to use `resources`. This fixes the issue wherein the builds uploaded to TestFlight from Xcode 13 don't show up the flag icons. 